### PR TITLE
Check if `self` is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 (function() {
   "use strict"
 
-  if (!self.document) return
+  if (typeof self === "undefined" || !self.document) return
 
   var event = KeyboardEvent.prototype
   var desc = Object.getOwnPropertyDescriptor(event, "key")


### PR DESCRIPTION
Hey Alexey, `self` might be undefined in some environments, which throws an error.

Your shim is currently used in `@reecelucas/react-use-hotkeys`, which, when used in Next.js, throws an error when `self` is undefined.

This PR should fix that.